### PR TITLE
Rename flushRules() to flushRewriteRules()

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -106,7 +106,7 @@ function checkRewriteRules()
 /**
  * Flush rewrite rules and remove rewrite flag
  */
-function flushRules()
+function flushRewriteRules()
 {
     flush_rewrite_rules();
 


### PR DESCRIPTION
Just a wrong naming which leads to missing function calls when deactivating the plugin.